### PR TITLE
Add ends-with workaround due to xpath 1.0 limitation

### DIFF
--- a/Basin.DuckDuckGoExample/Features/Search.feature.cs
+++ b/Basin.DuckDuckGoExample/Features/Search.feature.cs
@@ -35,7 +35,7 @@ namespace Basin.DuckDuckGoExample.Features
         public virtual void FeatureSetup()
         {
             testRunner = TechTalk.SpecFlow.TestRunnerManager.GetTestRunner();
-            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Search", "A short summary of the feature", ProgrammingLanguage.CSharp, ((string[])(null)));
+            TechTalk.SpecFlow.FeatureInfo featureInfo = new TechTalk.SpecFlow.FeatureInfo(new System.Globalization.CultureInfo("en-US"), "Search", "I must know about cats. I MUST!", ProgrammingLanguage.CSharp, ((string[])(null)));
             testRunner.OnFeatureStart(featureInfo);
         }
         

--- a/Basin.DuckDuckGoExample/Pages/ResultsPage.cs
+++ b/Basin.DuckDuckGoExample/Pages/ResultsPage.cs
@@ -8,19 +8,19 @@ namespace Basin.DuckDuckGoExample.Pages
     public class ResultsPage : Page<ResultsPageMap>
     {
         public readonly PageCollection OtherPages = new PageCollection();
-        
+
         public bool WordDefinitionDisplayed(string definition)
         {
             return Map.WordDefinition(definition).Displayed;
-            
+
         }
     }
 
     public class ResultsPageMap : PageMap
     {
-        public Element WordDefinition(string definition) => Div
+        public Element WordDefinition(string definition) => DivTag
             .WithClass("zci__def__definition")
             .WithText(definition)
-            .Inside(Div.WithId("zci-dictionary_definition"));
+            .Inside(DivTag.WithId("zci-dictionary_definition"));
     }
 }

--- a/Basin.DuckDuckGoExample/Pages/Shared/SearchFieldMap.cs
+++ b/Basin.DuckDuckGoExample/Pages/Shared/SearchFieldMap.cs
@@ -6,8 +6,8 @@ namespace Basin.DuckDuckGoExample.Pages.Shared
 {
     public class SearchFieldMap : PageMap
     {
-        public Element FromHomepage => TextField.WithId("search_form_input_homepage");
-        
-        public Element FromResults => TextField.WithId("search_form_input");
+        public Element FromHomepage => TextInputTag.WithId("search_form_input_homepage");
+
+        public Element FromResults => TextInputTag.WithId("search_form_input");
     }
 }

--- a/Basin/Basin.csproj
+++ b/Basin/Basin.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <PackageId>BasinFramework</PackageId>
-        <PackageVersion>0.0.84</PackageVersion>
+        <PackageVersion>0.0.85</PackageVersion>
         <Title>Basin Framework</Title>
         <Authors>Arik Jones</Authors>
         <LangVersion>8</LangVersion>
@@ -25,5 +24,4 @@
       <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
       <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     </ItemGroup>
-
 </Project>

--- a/Basin/Core/Locators/Locator.cs
+++ b/Basin/Core/Locators/Locator.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Text;
 using System.Text.RegularExpressions;
 using Basin.Core.Locators.Interfaces;
-using Basin.Selenium;
 using OpenQA.Selenium;
 
 namespace Basin.Core.Locators
@@ -72,8 +70,7 @@ namespace Basin.Core.Locators
 
         private static string GetXPathAttribute(string attr, string str)
         {
-
-            var xPathAttr = string.Empty;
+            string xPathAttr = "";
 
             if (StartsWithOperator(str))
             {
@@ -86,7 +83,9 @@ namespace Basin.Core.Locators
                         xPathAttr = $"[starts-with(@{attr}, '{newStr}')]";
                         break;
                     case "$":
-                        xPathAttr = $"[ends-with(@{attr}, '{newStr}')]";
+                        // Can't use ends-with because Selenium 3 doesn't use XPath 2.0.
+                        // So we have to make this unholy mess to get the same behavior in XPath 1.0
+                        xPathAttr = $"[substring(@{attr}, string-length(@{attr}) - string-length('{newStr}') +1)]";
                         break;
                     case "*":
                         xPathAttr = $"[contains(@{attr}, '{newStr}')]";

--- a/Basin/Core/Locators/Locator.cs
+++ b/Basin/Core/Locators/Locator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text;
 using System.Text.RegularExpressions;
 using Basin.Core.Locators.Interfaces;
@@ -39,18 +40,13 @@ namespace Basin.Core.Locators
 
         public ILocatorBuilder WithId(string id)
         {
-            var op = string.Empty;
-
-            if (IdHasOperator(id))
-                op = Regex.Match(id, @"^(\^|\~|\$|\||\*){1}").Value;
-
-            XPath.Append($"[@id{op}='{id}']");
+            XPath.Append(GetXPathAttribute("id", id));
             return this;
         }
 
         public ILocatorBuilder WithAttr(string name, string value)
         {
-            XPath.Append($"[@{name}='{value}']");
+            XPath.Append(GetXPathAttribute(name, value));
             return this;
         }
 
@@ -72,6 +68,36 @@ namespace Basin.Core.Locators
             return this;
         }
 
-        private static bool IdHasOperator(string id) => Regex.IsMatch(id, @"^(\^|\~|\$|\||\*){1}");
+        private static bool StartsWithOperator(string str) => Regex.IsMatch(str, @"^^(\^|\$|\*){1}");
+
+        private static string GetXPathAttribute(string attr, string str)
+        {
+
+            var xPathAttr = string.Empty;
+
+            if (StartsWithOperator(str))
+            {
+                var op = Regex.Match(str, @"^(\^|\$|\*){1}").Value;
+                var newStr = str.Remove(0, 1); // Remove operator
+
+                switch (op)
+                {
+                    case "^":
+                        xPathAttr = $"[starts-with(@{attr}, '{newStr}')]";
+                        break;
+                    case "$":
+                        xPathAttr = $"[ends-with(@{attr}, '{newStr}')]";
+                        break;
+                    case "*":
+                        xPathAttr = $"[contains(@{attr}, '{newStr}')]";
+                        break;
+                    default:
+                        xPathAttr = $"[@{attr}='{newStr}']";
+                        break;
+                }
+            }
+
+            return xPathAttr;
+        }
     }
 }


### PR DESCRIPTION
Properly uses the correct XPath function based on the operator symbol passed at the beginning of attribute values. Added a work-around for ends-with because Selenium 3.0 does not support XPath 2.0.