### PR TITLE
Housekeeping for v1.0.3

### DIFF
--- a/Basin.Tests/Steps/AddRemoveElementsSteps.cs
+++ b/Basin.Tests/Steps/AddRemoveElementsSteps.cs
@@ -17,7 +17,7 @@ namespace Basin.Tests.Steps
         {
             Assert.That(
                 Pages.AddRemoveElementsExample.HasNumberOfDeleteButtons(expectedCount),
-                $"Expected {expectedCount} Delete button(s) to be added. Got {Pages.AddRemoveElementsExample.Map.AllDeleteButtons.Count} instead.");
+                $"Expected {expectedCount} Delete button(s) to be displayed. Got {Pages.AddRemoveElementsExample.Map.AllDeleteButtons.Count} instead.");
         }
 
     }

--- a/Basin.Tests/Steps/StepsBase.cs
+++ b/Basin.Tests/Steps/StepsBase.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Basin.Config.Interfaces;
 using Basin.Selenium;
 using Basin.Selenium.Builders;
 using OpenQA.Selenium;
@@ -9,12 +10,10 @@ namespace Basin.Tests.Steps
     [Binding]
     public static class StepsBase
     {
-        private static readonly string ConfigPath = Path.GetFullPath("../../../");
-
         [BeforeFeature]
         public static void BeforeFeatureHook()
         {
-            BSN.SetConfig($"{ConfigPath}/TheInternet.json");
+            BSN.SetConfig($"{Path.GetFullPath("../../../")}/TheInternet.json");
         }
 
         [BeforeScenario]

--- a/Basin/Config/Interfaces/IDriverConfig.cs
+++ b/Basin/Config/Interfaces/IDriverConfig.cs
@@ -27,4 +27,17 @@ namespace Basin.Config.Interfaces
 
         Uri Host { get; set; }
     }
+
+    public class DriverConfig : IDriverConfig
+    {
+        public string Name { get; set; }
+        public string BrowserName { get; set; }
+        public int Timeout { get; set; }
+        public string PlatformName { get; set; }
+        public string BrowserVersion { get; set; }
+        public IEnumerable<string> Arguments { get; set; }
+        public bool Headless { get; set; }
+        public string PathToDriver { get; set; }
+        public Uri Host { get; set; }
+    }
 }

--- a/Basin/Config/Interfaces/ILoginConfig.cs
+++ b/Basin/Config/Interfaces/ILoginConfig.cs
@@ -7,4 +7,12 @@ namespace Basin.Config.Interfaces
         string Password { get; set; }
         string Token { get; set; }
     }
+
+    public class LoginConfig : ILoginConfig
+    {
+        public string Role { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
+        public string Token { get; set; }
+    }
 }

--- a/Basin/Config/Interfaces/ISiteConfig.cs
+++ b/Basin/Config/Interfaces/ISiteConfig.cs
@@ -5,4 +5,10 @@ namespace Basin.Config.Interfaces
         string Name { get; set; }
         string Url { get; set; }
     }
+
+    public class SiteConfig : ISiteConfig
+    {
+        public string Name { get; set; }
+        public string Url { get; set; }
+    }
 }

--- a/Basin/Core/Locators/Interfaces/IHtmlElements.cs
+++ b/Basin/Core/Locators/Interfaces/IHtmlElements.cs
@@ -101,5 +101,7 @@ namespace Basin.Core.Locators.Interfaces
         Element TextAreaTag { get; }
 
         Element TextInputTag { get; }
+
+        Element PasswordInputTag { get; }
     }
 }

--- a/Basin/Pages/PageMap.cs
+++ b/Basin/Pages/PageMap.cs
@@ -78,6 +78,8 @@ namespace Basin.Pages
 
         public Element ParagraphTag => new Element("p");
 
+        public Element PasswordInputTag => InputTag.WithAttr("type", "password");
+
         public Element RadioInputTag => InputTag.WithAttr("type", "radio");
 
         public Element SectionTag => new Element("section");

--- a/Basin/Selenium/Builders/ChromeBuilder.cs
+++ b/Basin/Selenium/Builders/ChromeBuilder.cs
@@ -19,6 +19,16 @@ namespace Basin.Selenium.Builders
 
         private readonly IDriverConfig _config;
 
+        public ChromeBuilder()
+        {
+            _config = new DriverConfig()
+            {
+                BrowserName = "chrome"
+            };
+
+            CreateService();
+            CreateOptions();
+        }
         public ChromeBuilder(IDriverConfig config)
         {
             _config = config;

--- a/Basin/Selenium/Builders/FirefoxBuilder.cs
+++ b/Basin/Selenium/Builders/FirefoxBuilder.cs
@@ -19,13 +19,24 @@ namespace Basin.Selenium.Builders
 
         private readonly IDriverConfig _config;
 
+        public FirefoxBuilder()
+        {
+            _config = new DriverConfig()
+            {
+                BrowserName = "firefox"
+            };
+
+            CreateService();
+            CreateOptions();
+        }
+
         public FirefoxBuilder(IDriverConfig config)
         {
             _config = config;
 
             CreateService();
             CreateOptions();
-            SetHeadless();
+            EnableHeadlessMode();
             SetPlatformName();
             SetBrowserVersion();
             AddArguments();
@@ -41,12 +52,6 @@ namespace Basin.Selenium.Builders
         public void CreateOptions()
         {
             _driverOptions = new FirefoxOptions();
-        }
-
-        public void SetHeadless()
-        {
-
-            _driverOptions.AddArgument("--headless");
         }
 
         public void SetPlatformName()
@@ -65,7 +70,7 @@ namespace Basin.Selenium.Builders
 
         public void AddArguments()
         {
-            if (_config.Arguments == null) return;
+            if (_config.Arguments?.Any() != true) return;
 
             _driverOptions.AddArguments(_config.Arguments);
         }
@@ -74,8 +79,7 @@ namespace Basin.Selenium.Builders
         {
             if (!_config.Headless) return;
 
-            _driverOptions.AddArgument("--headless");
-            _driverOptions.AddArgument("--disable-gpu");
+            _driverOptions.AddArgument("-headless");
         }
 
         public void SetHost()


### PR DESCRIPTION
- Fixed EnableHeadlessMode method for FirefoxBuilder
- Added derived classes for IDriverConfig, ISiteConfig, and ILoginConfig. Mostly to allow parameterless constructors for Chrome and Firefox builders
- Add parameterless constructors to Firefox and Chrome builders.
- Added PasswordInputTag to PageMap class