### PR TITLE
Add inclusivity feature to Locator methods

### DIFF
--- a/Basin.Tests/Features/NonInclusiveLocators.feature
+++ b/Basin.Tests/Features/NonInclusiveLocators.feature
@@ -1,0 +1,15 @@
+﻿Feature: Non-Inclusive Locators
+	In order to build a locator
+	As an Element
+	I want to be found based on properties I don't have
+
+@mytag
+Scenario: Locate element that excludes a given class name
+	Given I am on the home page
+	When I navigate to the example named 'Large & Deep DOM'
+	Then I can locate element '2.1' excluding class name 'tier-3'
+
+Scenario: Locate element that excludes a given descendant element
+	Given I am on the home page
+	When I navigate to the example named 'Large & Deep DOM'
+	Then I can locate element '2.1' excluding descendant element '1.1'

--- a/Basin.Tests/PageObjects/LargeAndDeepDOMExamplePage.cs
+++ b/Basin.Tests/PageObjects/LargeAndDeepDOMExamplePage.cs
@@ -1,5 +1,6 @@
 ﻿using Basin.PageObjects;
 using Basin.Selenium;
+using System;
 
 namespace Basin.Tests.PageObjects
 {
@@ -10,5 +11,9 @@ namespace Basin.Tests.PageObjects
         public Element ItemWithExactText(string text) => DivTag.WithText(text);
 
         public Element ItemContainingText(string text) => DivTag.WithText($"*|{text}");
+
+        public Element ItemWithoutClassName(string text, string className) => Item(text).WithClass(className, false);
+
+        public Element ItemWithoutDescedant(string elementText, string descendantText) => Item(elementText).WithDescendant(Item(descendantText), false);
     }
 }

--- a/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
+++ b/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
@@ -56,5 +56,17 @@ namespace Basin.Tests.Steps
         {
             Assert.That(Page.ItemWithExactText(text).Exists, Is.True);
         }
+
+        [Then("I can locate element '(.*?)' excluding class name '(.*?)'")]
+        public void ThenICanLocateElementWhichExcludesClassName(string elementText, string className)
+        {
+            Assert.That(Page.ItemWithoutClassName(elementText, className).Exists, Is.True);
+        }
+
+        [Then("I can locate element '(.*?)' excluding descendant element '(.*?)'")]
+        public void ThenICanLocateElementWhichExcludesDescendantElement(string elementText, string descendantText)
+        {
+            Assert.That(Page.ItemWithoutDescedant(elementText, descendantText).Exists, Is.True);
+        }
     }
 }

--- a/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
+++ b/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
@@ -51,7 +51,6 @@ namespace Basin.Tests.Steps
             Assert.That(Page.Item(elementText).Child(Page.Item(childText)).Exists);
         }
 
-
         [Then("I can locate an element with exact text '(.*?)'")]
         public void ThenICanLocateAnElementWithExactText(string text)
         {

--- a/Basin.Tests/Steps/StepsBase.cs
+++ b/Basin.Tests/Steps/StepsBase.cs
@@ -28,7 +28,7 @@ namespace Basin.Tests.Steps
         [AfterScenario]
         public void AfterScenarioHook()
         {
-            BrowserSession.Current?.Quit();
+            BrowserSession.Quit();
         }
     }
 }

--- a/Basin/Config/Interfaces/IBrowserConfig.cs
+++ b/Basin/Config/Interfaces/IBrowserConfig.cs
@@ -35,6 +35,9 @@ namespace Basin.Config.Interfaces
         Uri Host { get; set; }
 
         Dictionary<string, object> Capabilities { get; }
+        
+        [Option(DefaultValue = true)]
+        bool HideCommandPrompt { get; set; }
     }
 
     public class BrowserConfig : IBrowserConfig
@@ -54,6 +57,8 @@ namespace Basin.Config.Interfaces
         public IEnumerable<string> Arguments { get; set; }
 
         public bool Headless { get; set; }
+
+        public bool HideCommandPrompt { get; set; }
 
         public string PathToDriverBinary { get; set; }
 

--- a/Basin/Core/Browsers/InternetExplorerBrowser.cs
+++ b/Basin/Core/Browsers/InternetExplorerBrowser.cs
@@ -28,7 +28,6 @@ namespace Basin.Core.Browsers
 
         public void CreateDriver(Uri host)
         {
-
             Driver = (host == null)
                 ? new InternetExplorerDriver(Service, Options)
                 : new RemoteWebDriver(host, Options);

--- a/Basin/Core/Browsers/Mappers/ChromeServiceMapper.cs
+++ b/Basin/Core/Browsers/Mappers/ChromeServiceMapper.cs
@@ -6,25 +6,34 @@ namespace Basin.Core.Browsers.Mappers
 {
     public class ChromeServiceMapper : DriverServiceMap<ChromeDriverService>
     {
-        public override string PathToDriverBinary { get; set; }
+        public override string PathToDriverBinary { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
+
+        public override bool HideCommandPrompt { get; set; } = true;
+
+        public ChromeServiceMapper()
+        {
+            CreateService(PathToDriverBinary);
+        }
 
         public ChromeServiceMapper(IBrowserConfig config)
         {
-            PathToDriverBinary = config.PathToDriverBinary;
+            PathToDriverBinary = config.PathToDriverBinary ?? PathToDriverBinary;
+            HideCommandPrompt = config.HideCommandPrompt;
 
             CreateService(PathToDriverBinary);
         }
 
-        public ChromeServiceMapper(string pathToDriverBinary = null)
+        public ChromeServiceMapper(string pathToDriverBinary)
         {
             PathToDriverBinary = pathToDriverBinary;
 
             CreateService(PathToDriverBinary);
         }
 
-        private void CreateService(string pathToDriverBinary = null)
+        private void CreateService(string pathToDriverBinary)
         {
-            Service = ChromeDriverService.CreateDefaultService(pathToDriverBinary ?? AppDomain.CurrentDomain.BaseDirectory);
+            Service = ChromeDriverService.CreateDefaultService(pathToDriverBinary);
+            Service.HideCommandPromptWindow = HideCommandPrompt;
         }
     }
 }

--- a/Basin/Core/Browsers/Mappers/DriverServiceMap.cs
+++ b/Basin/Core/Browsers/Mappers/DriverServiceMap.cs
@@ -7,6 +7,8 @@ namespace Basin.Core.Browsers.Mappers
     {
         public abstract string PathToDriverBinary { get; set; }
 
+        public abstract bool HideCommandPrompt { get; set; }
+
         public TDriverService Service { get; set; }
     }
 }

--- a/Basin/Core/Browsers/Mappers/FirefoxServiceMapper.cs
+++ b/Basin/Core/Browsers/Mappers/FirefoxServiceMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Basin.Config.Interfaces;
 using OpenQA.Selenium.Firefox;
 
@@ -6,9 +7,16 @@ namespace Basin.Core.Browsers.Mappers
 {
     public class FirefoxServiceMapper : DriverServiceMap<FirefoxDriverService>
     {
-        public override string PathToDriverBinary { get; set; }
+        public override string PathToDriverBinary { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
 
-        public FirefoxServiceMapper(string pathToDriverBinary = null)
+        public override bool HideCommandPrompt { get; set; } = true;
+
+        public FirefoxServiceMapper()
+        {
+            CreateService(PathToDriverBinary);
+        }
+
+        public FirefoxServiceMapper(string pathToDriverBinary)
         {
             PathToDriverBinary = pathToDriverBinary;
 
@@ -17,12 +25,16 @@ namespace Basin.Core.Browsers.Mappers
 
         public FirefoxServiceMapper(IBrowserConfig config)
         {
+            PathToDriverBinary = config.PathToDriverBinary ?? PathToDriverBinary;
+            HideCommandPrompt = config.HideCommandPrompt;
+
             CreateService(config.PathToDriverBinary);
         }
 
-        private void CreateService(string pathToDriverBinary = null)
+        private void CreateService(string pathToDriverBinary)
         {
-            Service = FirefoxDriverService.CreateDefaultService(pathToDriverBinary ?? AppDomain.CurrentDomain.BaseDirectory);
+            Service = FirefoxDriverService.CreateDefaultService(pathToDriverBinary);
+            Service.HideCommandPromptWindow = HideCommandPrompt;
         }
     }
 }

--- a/Basin/Core/Browsers/Mappers/InternetExplorerServiceMapper.cs
+++ b/Basin/Core/Browsers/Mappers/InternetExplorerServiceMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Basin.Config.Interfaces;
 using OpenQA.Selenium.IE;
 
@@ -6,9 +7,16 @@ namespace Basin.Core.Browsers.Mappers
 {
     public class InternetExplorerServiceMapper : DriverServiceMap<InternetExplorerDriverService>
     {
-        public override string PathToDriverBinary { get; set; }
+        public override string PathToDriverBinary { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
 
-        public InternetExplorerServiceMapper(string pathToDriverBinary = null)
+        public override bool HideCommandPrompt { get; set; } = true;
+
+        public InternetExplorerServiceMapper()
+        {
+            CreateService(PathToDriverBinary);
+        }
+
+        public InternetExplorerServiceMapper(string pathToDriverBinary)
         {
             PathToDriverBinary = pathToDriverBinary;
 
@@ -17,12 +25,16 @@ namespace Basin.Core.Browsers.Mappers
 
         public InternetExplorerServiceMapper(IBrowserConfig config)
         {
-            CreateService(config.PathToDriverBinary);
+            PathToDriverBinary = config.PathToDriverBinary ?? PathToDriverBinary;
+            HideCommandPrompt = config.HideCommandPrompt;
+
+            CreateService(PathToDriverBinary);
         }
 
-        private void CreateService(string pathToDriverBinary = null)
+        private void CreateService(string pathToDriverBinary)
         {
-            Service = InternetExplorerDriverService.CreateDefaultService(pathToDriverBinary ?? AppDomain.CurrentDomain.BaseDirectory);
+            Service = InternetExplorerDriverService.CreateDefaultService(pathToDriverBinary);
+            Service.HideCommandPromptWindow = HideCommandPrompt;
         }
     }
 }

--- a/Basin/Core/Locators/ILocatorBuilder.cs
+++ b/Basin/Core/Locators/ILocatorBuilder.cs
@@ -11,19 +11,19 @@ namespace Basin.Core.Locators
 
         ILocatorBuilder Inside(ILocatorBuilder parent);
 
-        ILocatorBuilder WithText(string text);
+        ILocatorBuilder WithText(string text, bool inclusive = true);
 
-        ILocatorBuilder WithClass(string className);
+        ILocatorBuilder WithClass(string className, bool inclusive = true);
 
-        ILocatorBuilder WithId(string id);
+        ILocatorBuilder WithId(string id, bool inclusive = true);
 
-        ILocatorBuilder WithAttr(string name);
+        ILocatorBuilder WithAttr(string name, bool inclusive = true);
 
-        ILocatorBuilder WithAttr(string name, string value);
+        ILocatorBuilder WithAttr(string name, string value, bool inclusive = true);
 
-        ILocatorBuilder WithChild(ILocatorBuilder child);
+        ILocatorBuilder WithChild(ILocatorBuilder child, bool inclusive = true);
 
-        ILocatorBuilder WithDescendant(ILocatorBuilder descendant);
+        ILocatorBuilder WithDescendant(ILocatorBuilder descendant, bool inclusive = true);
 
         ILocatorBuilder Child();
 

--- a/Basin/PageObjects/PageCollection.cs
+++ b/Basin/PageObjects/PageCollection.cs
@@ -28,7 +28,7 @@ namespace Basin.PageObjects
             var pageKey = typeof(TPage).ToString();
 
             if (!Pages.ContainsKey(pageKey))
-                throw new NullReferenceException($"Collection does not contain a page with key `{pageKey}`."); ;
+                throw new NullReferenceException($"Collection does not contain a page with key `{pageKey}`.");
 
             Pages.TryGetValue(pageKey, out object page);
 

--- a/Basin/Selenium/BrowserSession.cs
+++ b/Basin/Selenium/BrowserSession.cs
@@ -38,6 +38,7 @@ namespace Basin.Selenium
 
         public static void Quit()
         {
+            Current.Close();
             Current.Quit();
         }
 

--- a/Basin/Selenium/Element.cs
+++ b/Basin/Selenium/Element.cs
@@ -9,10 +9,8 @@ using OpenQA.Selenium.Support.UI;
 
 namespace Basin.Selenium
 {
-    public sealed class Element : IWebElement
+    public sealed class Element : IWebElement, IElement
     {
-        // private readonly IWebElement _element;
-
         private readonly int _timeout;
 
         private readonly ILocatorBuilder _locator;
@@ -26,8 +24,6 @@ namespace Basin.Selenium
         public string Description { get; set; }
 
         public By FoundBy { get; set; }
-
-        public By ParentFoundBy { get; set; }
 
         private DefaultWait<IWebDriver> Wait
         {
@@ -76,8 +72,7 @@ namespace Basin.Selenium
             }
         }
 
-        private IWebElement Current => Locate ??
-            throw new NullReferenceException("Element could not be located because it was null");
+        private IWebElement Current => Locate ?? throw new NullReferenceException("Element could not be located because it was null");
 
         public Func<IWebDriver, bool> IsDisplaying => WaitConditions.ElementDisplayed(Current);
 
@@ -97,50 +92,23 @@ namespace Basin.Selenium
 
         public bool Displayed => Current.Displayed;
 
-        public void Clear()
-        {
-            Current.Clear();
-        }
+        public void Clear() => Current.Clear();
 
-        public void Click()
-        {
-            Current.Click();
-        }
+        public void Click() => Current.Click();
 
-        public IWebElement FindElement(By by)
-        {
-            return Current.FindElement(by);
-        }
+        public IWebElement FindElement(By by) => Current.FindElement(by);
 
-        public ReadOnlyCollection<IWebElement> FindElements(By by)
-        {
-            return Current.FindElements(by);
-        }
+        public ReadOnlyCollection<IWebElement> FindElements(By by) => Current.FindElements(by);
 
-        public string GetAttribute(string attributeName)
-        {
-            return Current.GetAttribute(attributeName);
-        }
+        public string GetAttribute(string attributeName) => Current.GetAttribute(attributeName);
 
-        public string GetCssValue(string propertyName)
-        {
-            return Current.GetCssValue(propertyName);
-        }
+        public string GetCssValue(string propertyName) => Current.GetCssValue(propertyName);
 
-        public string GetProperty(string propertyName)
-        {
-            return Current.GetProperty(propertyName);
-        }
+        public string GetProperty(string propertyName) => Current.GetProperty(propertyName);
 
-        public void SendKeys(string text)
-        {
-            Current.SendKeys(text);
-        }
+        public void SendKeys(string text) => Current.SendKeys(text);
 
-        public void Submit()
-        {
-            Current.Submit();
-        }
+        public void Submit() => Current.Submit();
 
         public void Hover()
         {
@@ -156,37 +124,37 @@ namespace Basin.Selenium
             return this;
         }
 
-        public Element WithText(string text)
+        public Element WithText(string text, bool inclusive = true)
         {
-            _locator.WithText(text);
+            _locator.WithText(text, inclusive);
 
             return this;
         }
 
-        public Element WithClass(string className)
+        public Element WithClass(string className, bool inclusive = true)
         {
-            _locator.WithClass(className);
+            _locator.WithClass(className, inclusive);
 
             return this;
         }
 
-        public Element WithId(string id)
+        public Element WithId(string id, bool inclusive = true)
         {
-            _locator.WithId(id);
+            _locator.WithId(id, inclusive);
 
             return this;
         }
 
-        public Element WithAttr(string name)
+        public Element WithAttr(string name, bool inclusive = true)
         {
-            _locator.WithAttr(name);
+            _locator.WithAttr(name, inclusive);
 
             return this;
         }
 
-        public Element WithAttr(string name, string value)
+        public Element WithAttr(string name, string value, bool inclusive = true)
         {
-            _locator.WithAttr(name, value);
+            _locator.WithAttr(name, value, inclusive);
 
             return this;
         }

--- a/Basin/Selenium/Element.cs
+++ b/Basin/Selenium/Element.cs
@@ -159,16 +159,16 @@ namespace Basin.Selenium
             return this;
         }
 
-        public Element WithChild(Element child)
+        public Element WithChild(Element child, bool inclusive = true)
         {
-            _locator.WithChild(child._locator);
+            _locator.WithChild(child._locator, inclusive);
 
             return this;
         }
 
-        public Element WithDescendant(Element descendant)
+        public Element WithDescendant(Element descendant, bool inclusive = true)
         {
-            _locator.WithDescendant(descendant._locator);
+            _locator.WithDescendant(descendant._locator, inclusive);
 
             return this;
         }

--- a/Basin/Selenium/IElement.cs
+++ b/Basin/Selenium/IElement.cs
@@ -21,9 +21,9 @@ namespace Basin.Selenium
         Element Precedes(Element element);
         Element WithAttr(string name, bool inclusive = true);
         Element WithAttr(string name, string value, bool inclusive = true);
-        Element WithChild(Element child);
+        Element WithChild(Element child, bool inclusive = true);
         Element WithClass(string className, bool inclusive = true);
-        Element WithDescendant(Element descendant);
+        Element WithDescendant(Element descendant, bool inclusive = true);
         Element WithId(string id, bool inclusive = true);
         Element WithText(string text, bool inclusive = true);
     }

--- a/Basin/Selenium/IElement.cs
+++ b/Basin/Selenium/IElement.cs
@@ -1,0 +1,30 @@
+using System;
+using OpenQA.Selenium;
+
+namespace Basin.Selenium
+{
+    public interface IElement
+    {
+        string Description { get; set; }
+        By FoundBy { get; set; }
+        Func<IWebDriver, bool> IsDisplaying { get; }
+        Func<IWebDriver, bool> IsNotDisplaying { get; }
+        Elements All { get; }
+        Element As(string description);
+        Element Child();
+        Element Child(Element element);
+        Element Follows(Element element);
+        Element IfTextMatches(string pattern);
+        Element Inside(Element parent);
+        Element Parent();
+        Element Parent(Element element);
+        Element Precedes(Element element);
+        Element WithAttr(string name, bool inclusive = true);
+        Element WithAttr(string name, string value, bool inclusive = true);
+        Element WithChild(Element child);
+        Element WithClass(string className, bool inclusive = true);
+        Element WithDescendant(Element descendant);
+        Element WithId(string id, bool inclusive = true);
+        Element WithText(string text, bool inclusive = true);
+    }
+}


### PR DESCRIPTION
There was no way to find elements based on properties that aren't included. Now its easy by passing false as the last argument on locator methods. This is not supported on `Child()`, `Inside()`, or `Parent()` locator methods.

```c#
DivTag.WithClass("foo") // Will locate a div tag that has "foo" as a class name
DivTag.WithClass("foo", false) // Will locate a div tag that does NOT have "foo" as a class name.
```