### PR TITLE
Locate elements by multiple classes in an element's class attribute

### DIFF
--- a/Basin.Tests/Features/ChildLocator.feature
+++ b/Basin.Tests/Features/ChildLocator.feature
@@ -1,11 +1,11 @@
 Feature: Child Locator
 
-    Background: Navigate to "Large & Deep DOM"
-        Given I am on the home page
-        And I navigate to the example named 'Large & Deep DOM'
+Background: Navigate to "Large & Deep DOM"
+	Given I am on the home page
+	And I navigate to the example named 'Large & Deep DOM'
 
-    Scenario: Locates child of element
-		Then I can locate the first child of element
+Scenario: Locates child of element
+	Then I can locate the first child of element
 
-	Scenario: Locates specific child of element
-		Then I can locate child '13.2' of element '13.1'
+Scenario: Locates specific child of element
+	Then I can locate child '13.2' of element '13.1'

--- a/Basin.Tests/Features/ElementsWithText.feature
+++ b/Basin.Tests/Features/ElementsWithText.feature
@@ -1,21 +1,18 @@
 Feature: Locate element by text
 
-    Background:
-        Given I am on the home page
-        When I navigate to the example named 'Dynamic Controls'
-        And I remove the checkbox
+Background:
+	Given I am on the home page
+	When I navigate to the example named 'Dynamic Controls'
+	And I remove the checkbox
 
-    Scenario: Element with exact text
-        Then I can locate a message with exact text 'It's gone!'
+Scenario: Element with exact text
+	Then I can locate a message with exact text 'It's gone!'
 
-    Scenario: Element that contains text
-        Then I can locate a message that contains text 'gon'
+Scenario: Element that contains text
+	Then I can locate a message that contains text 'gon'
 
-    Scenario: Element that starts with text
-        Then I can locate a message that starts with text 'It'
+Scenario: Element that starts with text
+	Then I can locate a message that starts with text 'It'
 
-    Scenario: Element that ends with text
-        Then I can locate a message that ends with text 'one!'
-    
-
-        
+Scenario: Element that ends with text
+	Then I can locate a message that ends with text 'one!'

--- a/Basin.Tests/Features/LocateByClassName.feature
+++ b/Basin.Tests/Features/LocateByClassName.feature
@@ -1,0 +1,19 @@
+﻿Feature: Locate elements by the value of their class attibrute
+	In order to be located
+	As an Element
+	I want to be found based on my class attribute
+
+Scenario: Locate element with a specific css class name
+	Given I am on the home page
+	And I navigate to the example named 'Large & Deep DOM'
+	Then I can locate element '1.2' whose class attribute includes class name 'tier-1'
+
+Scenario: Locate element with multiple class names
+	Given I am on the home page
+	And I navigate to the example named 'Large & Deep DOM'
+	Then I can locate element '1.2' who class attribute includes multiple class names 'tier-1, item-2, large-12'
+
+Scenario: Locate element with multiple class names with one exclusion
+	Given I am on the home page
+	And I navigate to the example named 'Large & Deep DOM'
+	Then I can locate element '1.2' who class attribute includes multiple class names '!tier-2, item-2, large-12'

--- a/Basin.Tests/Features/NonInclusiveLocators.feature
+++ b/Basin.Tests/Features/NonInclusiveLocators.feature
@@ -1,9 +1,8 @@
 ﻿Feature: Non-Inclusive Locators
-	In order to build a locator
+	In order to be located
 	As an Element
 	I want to be found based on properties I don't have
 
-@mytag
 Scenario: Locate element that excludes a given class name
 	Given I am on the home page
 	When I navigate to the example named 'Large & Deep DOM'

--- a/Basin.Tests/Features/ParentLocator.feature
+++ b/Basin.Tests/Features/ParentLocator.feature
@@ -1,13 +1,12 @@
 Feature: Parent Locators
+	Find MY PARENTS! I'm LOST!
 
-  Find MY PARENTS! I'm LOST!
+Background:
+	Given I am on the home page
+	When I navigate to the example named 'Large & Deep DOM'
 
-  Background:
-    Given I am on the home page
-    When I navigate to the example named 'Large & Deep DOM'
+Scenario: Locates parent of element
+	Then I can locate the first parent of element
 
-  Scenario: Locates parent of element
-    Then I can locate the first parent of element
-
-  Scenario: Locates specific parent of element
-    Then I can locate parent '1.1' of element '2.1'
+Scenario: Locates specific parent of element
+	Then I can locate parent '1.1' of element '2.1'

--- a/Basin.Tests/Features/SiblingLocator.feature
+++ b/Basin.Tests/Features/SiblingLocator.feature
@@ -1,11 +1,11 @@
 Feature: Sibling Locator
 
-    Background:
-        Given I am on the home page
-		When I navigate to the example named 'Large & Deep DOM'
+Background:
+	Given I am on the home page
+	When I navigate to the example named 'Large & Deep DOM'
 
-    Scenario: Locates an element by its following element
-		Then I can locate element '1.3' that follows element '1.2'
+Scenario: Locates an element by its following element
+	Then I can locate element '1.3' that follows element '1.2'
 
-	Scenario: Locates an element by its preceding element
-		Then I can locate element '1.2' that precedes element '1.3'
+Scenario: Locates an element by its preceding element
+	Then I can locate element '1.2' that precedes element '1.3'

--- a/Basin.Tests/Features/TheInternetExamples.feature
+++ b/Basin.Tests/Features/TheInternetExamples.feature
@@ -1,15 +1,14 @@
 ﻿Feature: Basin Functional Tests
-
 	MUST LOCATE THE THINGS!!!
 
-	Background:
-		Given I am on the home page
+Background:
+	Given I am on the home page
 
-	Scenario: Locates an element added to the page
-		When I navigate to the example named 'Add/Remove Elements'
-		And I add an element to the page
-		Then I can see 1 Delete button has been added
+Scenario: Locates an element added to the page
+	When I navigate to the example named 'Add/Remove Elements'
+	And I add an element to the page
+	Then I can see 1 Delete button has been added
 
-	Scenario: Locates element at a given position among multiple elements
-		When I navigate to the example named 'Large & Deep DOM'
-		Then I can locate a table cell in row 23 at column 6 whose text is '23.6'
+Scenario: Locates element at a given position among multiple elements
+	When I navigate to the example named 'Large & Deep DOM'
+	Then I can locate a table cell in row 23 at column 6 whose text is '23.6'

--- a/Basin.Tests/PageObjects/LargeAndDeepDOMExamplePage.cs
+++ b/Basin.Tests/PageObjects/LargeAndDeepDOMExamplePage.cs
@@ -13,14 +13,13 @@ namespace Basin.Tests.PageObjects
 
         public Element ItemWithoutClassName(string text, string className) => Item(text).WithClass(className, false);
 
-        public Element ItemWithoutDescedant(string elementText, string descendantText) => Item(elementText).WithDescendant(Item(descendantText), false);
+        public Element ItemWithMultipleClasses(string text, params string[] classNames) => Item(text).WithClass(classNames);
 
-        //public Element SomeElement => Css("table#large-table > tbody > tr:nth-child(23) > td:nth-child(10)");
+        public Element ItemWithoutDescedant(string elementText, string descendantText) => Item(elementText).WithDescendant(Item(descendantText), false);
 
         public Element TableCellByRowAndColumn(int row, int column) => TableTag.WithId("large-table")
                                                                                .Child(TableBodyTag)
                                                                                .Child(TableRowTag.AtPosition(row))
                                                                                .Child(TableCellTag.AtPosition(column));
-
     }
 }

--- a/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
+++ b/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
@@ -2,6 +2,8 @@ using NUnit.Framework;
 using TechTalk.SpecFlow;
 using Basin.Tests.PageObjects;
 using Basin.PageObjects;
+using System.Runtime.InteropServices.ComTypes;
+using System.Linq;
 
 namespace Basin.Tests.Steps
 {
@@ -73,6 +75,24 @@ namespace Basin.Tests.Steps
         public void ThenICanLocateATableCellByRowAndColumnWithGivenText(int row, int column, string text)
         {
             Assert.That(Page.TableCellByRowAndColumn(row, column).Text == text, Is.True);
+        }
+
+        [Then("I can locate element '(.*?)' whose class attribute includes class name '(.*?)'")]
+        public void ThenICanLocateElementWhoseClassAttributeIncludesClassName(string elementText, string className)
+        {
+            Assert.That(Page.Item(elementText).WithClass(className).Displayed, Is.True);
+        }
+
+        [StepArgumentTransformation]
+        public string[] ConvertCommaSeparatedStringToStringArray(string commaSeparatedValue)
+        {
+            return commaSeparatedValue.Replace(" ", "").Split(",");
+        }
+
+        [Then("I can locate element '(.*?)' who class attribute includes multiple class names '(.*?)'")]
+        public void ThenICanLocateElementWhoseClassAttributeIncludesMultipleClassNames(string elementText, string[] multipleClassNames)
+        {
+            Assert.That(Page.Item(elementText).WithClass(multipleClassNames.ToArray()).Displayed, Is.True);
         }
     }
 }

--- a/Basin/Core/Locators/ILocatorBuilder.cs
+++ b/Basin/Core/Locators/ILocatorBuilder.cs
@@ -15,6 +15,8 @@ namespace Basin.Core.Locators
 
         ILocatorBuilder WithClass(string className, bool inclusive = true);
 
+        ILocatorBuilder WithClass(params string[] classNames);
+
         ILocatorBuilder WithId(string id, bool inclusive = true);
 
         ILocatorBuilder WithAttr(string name, bool inclusive = true);

--- a/Basin/Core/Locators/Locator.cs
+++ b/Basin/Core/Locators/Locator.cs
@@ -2,6 +2,7 @@ using System.Xml.XPath;
 using System.Text;
 using System.Text.RegularExpressions;
 using OpenQA.Selenium;
+using System.Linq;
 
 namespace Basin.Core.Locators
 {
@@ -46,6 +47,18 @@ namespace Basin.Core.Locators
             if (!inclusive) Selector.Append(")");
 
             Selector.Append("]");
+
+            return this;
+        }
+
+        public ILocatorBuilder WithClass(params string[] classNames)
+        {
+            for (int i = 0; i < classNames.Length; i++)
+                classNames[i] = GetClassNameXPath(classNames[i]);
+
+            Selector.Append("[")
+                    .AppendJoin(" and ", classNames)
+                    .Append("]");
 
             return this;
         }
@@ -167,6 +180,22 @@ namespace Basin.Core.Locators
                     .Append("]");
 
             return this;
+        }
+
+        private static string GetClassNameXPath(string className)
+        {
+            var classNameXpath = new StringBuilder();
+            bool exclude = Regex.IsMatch(className, "^!");
+
+            if (exclude) classNameXpath.Append("not(");
+
+            classNameXpath.Append("contains(concat(' ',normalize-space(@class),' '),' ")
+                          .Append(className.Replace("!", ""))
+                          .Append(" ')");
+
+            if (exclude) classNameXpath.Append(")");
+
+            return classNameXpath.ToString();
         }
 
         private static string GetXPathStringFunc(string attrOrFuncName, string attrOrFuncValue, bool inclusive = true)

--- a/Basin/PageObjects/Page.cs
+++ b/Basin/PageObjects/Page.cs
@@ -15,13 +15,10 @@ namespace Basin.PageObjects
 
     public abstract class Page<TPageMap> : IPageBase where TPageMap : new()
     {
-        private readonly TPageMap _map = new TPageMap();
 
         public Wait Wait => BrowserSession.Wait;
 
-        // public TPage On<TPage>() where TPage : new() => new TPage();
-
-        public TPageMap Map => _map ?? throw new NullReferenceException("Map is null. Set with an instance of PageMap");
+        public TPageMap Map { get; } = new TPageMap();
     }
 
     public abstract class PageComponent : Page { }

--- a/Basin/Selenium/Element.cs
+++ b/Basin/Selenium/Element.cs
@@ -138,6 +138,13 @@ namespace Basin.Selenium
             return this;
         }
 
+        public Element WithClass(params string[] classNames)
+        {
+            _locator.WithClass(classNames);
+
+            return this;
+        }
+
         public Element WithId(string id, bool inclusive = true)
         {
             _locator.WithId(id, inclusive);

--- a/Basin/Selenium/IElement.cs
+++ b/Basin/Selenium/IElement.cs
@@ -94,6 +94,12 @@ namespace Basin.Selenium
         Element WithClass(string className, bool inclusive = true);
 
         /// <summary>
+        /// Locate element with a class attribute containing multiple class names.
+        /// </summary>
+        /// <param name="classNames">param string array of HTML class names</param>
+        Element WithClass(params string[] classNames);
+
+        /// <summary>
         /// Locate element containing specific descendant elements
         /// </summary>
         /// <param name="descendantElement"></param>


### PR DESCRIPTION
# Highlights

:heavy_plus_sign: Add ability to locate elements by multiple class names for an page element

# Other Notes

Includes some minor changes to other parts of the Locator class.
