### PR TITLE
Add support for traditional By locators

### DIFF
--- a/Basin.Tests/Features/TheInternetExamples.feature
+++ b/Basin.Tests/Features/TheInternetExamples.feature
@@ -12,3 +12,7 @@ Scenario: Locates an element added to the page
 Scenario: Locates element at a given position among multiple elements
 	When I navigate to the example named 'Large & Deep DOM'
 	Then I can locate a table cell in row 23 at column 6 whose text is '23.6'
+
+Scenario: Locate element using traditional By method
+	When I navigate to the example named 'Large & Deep DOM'
+	Then I can locate element using By.Id 'sibling-2.1'

--- a/Basin.Tests/PageObjects/HomePage.cs
+++ b/Basin.Tests/PageObjects/HomePage.cs
@@ -19,7 +19,7 @@ namespace Basin.Tests.PageObjects
         public void BuildExamples()
         {
             Examples.Add(new AddRemoveElementsExamplePage());
-            Examples.Add(new LargeAndDeepDOMExamplePage());
+            Examples.Add(new LargeAndDeepDomExamplePage());
         }
     }
 }

--- a/Basin.Tests/PageObjects/LargeAndDeepDOMExamplePage.cs
+++ b/Basin.Tests/PageObjects/LargeAndDeepDOMExamplePage.cs
@@ -1,9 +1,10 @@
 ﻿using Basin.PageObjects;
 using Basin.Selenium;
+using OpenQA.Selenium;
 
 namespace Basin.Tests.PageObjects
 {
-    public class LargeAndDeepDOMExamplePage : Page
+    public class LargeAndDeepDomExamplePage : Page
     {
         public Element Item(string text) => DivTag.WithId($"sibling-{text}");
 
@@ -13,13 +14,18 @@ namespace Basin.Tests.PageObjects
 
         public Element ItemWithoutClassName(string text, string className) => Item(text).WithClass(className, false);
 
-        public Element ItemWithMultipleClasses(string text, params string[] classNames) => Item(text).WithClass(classNames);
+        public Element ItemWithMultipleClasses(string text, params string[] classNames) =>
+            Item(text).WithClass(classNames);
 
-        public Element ItemWithoutDescedant(string elementText, string descendantText) => Item(elementText).WithDescendant(Item(descendantText), false);
+        public Element ItemWithoutDescedant(string elementText, string descendantText) =>
+            Item(elementText).WithDescendant(Item(descendantText), false);
 
-        public Element TableCellByRowAndColumn(int row, int column) => TableTag.WithId("large-table")
-                                                                               .Child(TableBodyTag)
-                                                                               .Child(TableRowTag.AtPosition(row))
-                                                                               .Child(TableCellTag.AtPosition(column));
+        public Element TableCellByRowAndColumn(int row, int column) => TableTag
+            .WithId("large-table")
+            .Child(TableBodyTag)
+            .Child(TableRowTag.AtPosition(row))
+            .Child(TableCellTag.AtPosition(column));
+
+        public Element ItemById(string id) => Locate(By.Id(id));
     }
 }

--- a/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
+++ b/Basin.Tests/Steps/LargeAndDeepDomExampleSteps.cs
@@ -2,7 +2,6 @@ using NUnit.Framework;
 using TechTalk.SpecFlow;
 using Basin.Tests.PageObjects;
 using Basin.PageObjects;
-using System.Runtime.InteropServices.ComTypes;
 using System.Linq;
 
 namespace Basin.Tests.Steps
@@ -10,7 +9,7 @@ namespace Basin.Tests.Steps
     [Binding]
     public class LargeAndDeepDomExampleSteps
     {
-        private LargeAndDeepDOMExamplePage Page => Pages.Get<LargeAndDeepDOMExamplePage>();
+        private LargeAndDeepDomExamplePage Page => Pages.Get<LargeAndDeepDomExamplePage>();
 
         [Then("I can locate element '(.*?)' that follows element '(.*?)'")]
         public void ThenICanLocateElementThatFollowsElement(string elementText, string siblingElementText)
@@ -93,6 +92,12 @@ namespace Basin.Tests.Steps
         public void ThenICanLocateElementWhoseClassAttributeIncludesMultipleClassNames(string elementText, string[] multipleClassNames)
         {
             Assert.That(Page.Item(elementText).WithClass(multipleClassNames.ToArray()).Displayed, Is.True);
+        }
+
+        [Then(@"I can locate element using By\.Id '(.*?)'")]
+        public void ThenICanLocateElementById(string elementId)
+        {
+            Assert.That(Page.ItemById($"{elementId}").Displayed, Is.True);
         }
     }
 }

--- a/Basin.Tests/Steps/StepsBase.cs
+++ b/Basin.Tests/Steps/StepsBase.cs
@@ -15,7 +15,7 @@ namespace Basin.Tests.Steps
             BasinEnv.SetConfig($"{Path.GetFullPath("../../../")}/TheInternet.json");
             Pages.Add(new HomePage());
             Pages.Add(new AddRemoveElementsExamplePage());
-            Pages.Add(new LargeAndDeepDOMExamplePage());
+            Pages.Add(new LargeAndDeepDomExamplePage());
             Pages.Add(new DynamicControlsExamplePage());
         }
 

--- a/Basin/Core/Locators/Locator.cs
+++ b/Basin/Core/Locators/Locator.cs
@@ -1,15 +1,11 @@
-using System.Xml.XPath;
 using System.Text;
 using System.Text.RegularExpressions;
 using OpenQA.Selenium;
-using System.Linq;
 
 namespace Basin.Core.Locators
 {
     public sealed class Locator : ILocatorBuilder
     {
-        public delegate ILocatorBuilder ContainsChild(ILocatorBuilder child);
-
         public By By => By.XPath(Selector.ToString());
 
         public StringBuilder Selector { get; }

--- a/Basin/PageObjects/PageMap.cs
+++ b/Basin/PageObjects/PageMap.cs
@@ -1,9 +1,12 @@
 using Basin.Selenium;
+using OpenQA.Selenium;
 
 namespace Basin.PageObjects
 {
     public abstract class PageMap
     {
+        protected Element Locate(By by) => new Element(by);
+
         protected Element AbbreviationTag => new Element("abbr");
 
         protected Element AbbrTag => AbbreviationTag;

--- a/Basin/Selenium/Element.cs
+++ b/Basin/Selenium/Element.cs
@@ -17,6 +17,19 @@ namespace Basin.Selenium
 
         private readonly ILocatorBuilder _locator;
 
+        public Element()
+        {
+            _wait = new DefaultWait<IWebDriver>(BrowserSession.Current);
+            _timeout = BasinEnv.Browser.ElementTimeout;
+        }
+
+        public Element(By by)
+        {
+            FoundBy = by;
+            _wait = new DefaultWait<IWebDriver>(BrowserSession.Current);
+            _timeout = BasinEnv.Browser.ElementTimeout;
+        }
+
         public Element(string tagName)
         {
             _wait = new DefaultWait<IWebDriver>(BrowserSession.Current);
@@ -44,7 +57,7 @@ namespace Basin.Selenium
         {
             get
             {
-                FoundBy = _locator.By;
+                FoundBy ??= _locator.By;
 
                 return Wait.Until(driver =>
                 {


### PR DESCRIPTION
# Highlights
:green_heart: Bring back ability to locate elements using traditional By class methods (e.g, `By.CssSelector`, etc)

# Other Notes

This change just add an overload to the `Element` class and a `Locate(By by)` property `PageMap`.
